### PR TITLE
sort planets by orbital period

### DIFF
--- a/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
+++ b/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
@@ -204,7 +204,9 @@ public class PlanetSelectionScreen extends Screen implements MenuAccess<PlanetSe
 
         // All buttons are data-driven; they are created from files in the /planet_data/planets directory.
         List<Planet> planets = new ArrayList<>(PlanetData.planets().values());
-        planets.sort(Comparator.comparing(g -> g.translation().substring(Math.abs(g.translation().indexOf(".text")))));
+        // sort planets based on their orbital period
+        planets.sort(Comparator.comparing(p -> p.daysInYear()));
+
         planets.forEach(planet -> {
             Category galaxyCategory = new Category(planet.galaxy(), Category.GALAXY_CATEGORY);
             Category solarSystemCategory = new Category(planet.solarSystem(), galaxyCategory);

--- a/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
+++ b/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
@@ -318,10 +318,11 @@ public class PlanetSelectionScreen extends Screen implements MenuAccess<PlanetSe
     public Button createButton(int row, int column, Component label, Category category, int colour, int sizeX, int sizeY, TooltipType tooltip, Planet planetInfo, Consumer<Button> onClick) {
         LinkedList<ExtendedButton> buttons = this.categoryButtons.getOrDefault(category, new LinkedList<>());
 
-        float colorR = (float) ((colour << 16) & 0xFF) / 255.0f;
-        float colorG = (float) ((colour << 8) & 0xFF) / 255.0f;
-        float colorB = (float) (colour & 0xFF) / 255.0f;
-        ExtendedButton button = new ExtendedButton(row, column, sizeX, sizeY, colorR, colorG, colorB, label, onClick::accept, (button1) -> renderButtonTooltip(planetInfo, tooltip, button1));
+        float colourR = (float) ((colour & 0xff0000) >> 16) / 255.0f;
+        float colourG = (float) ((colour & 0x00ff00) >> 8) / 255.0f;
+        float colourB = (float) ((colour & 0x0000ff)) / 255.0f;
+
+        ExtendedButton button = new ExtendedButton(row, column, sizeX, sizeY, colourR, colourG, colourB, label, onClick::accept, (button1) -> renderButtonTooltip(planetInfo, tooltip, button1));
         this.addRenderableWidget(button);
 
         buttons.add(button);


### PR DESCRIPTION
This results in planets in the selection menu being rendered in their typical orbital order: mercury, venus, earth, mars, ...etc.  Works on moons as well.

Also, this fixes the colours of the buttons on the planet selection screen.  The bit masking was off which is why only black and blue were possible.

![sort-colour](https://github.com/Argent-Matter/gcyr/assets/218132/ef8b9f95-17b3-4c85-8f73-76df72b4db03)
