### PR TITLE
fix co_mn_br catalyst recipe #36

### DIFF
--- a/src/main/java/argent_matter/gcyr/data/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/argent_matter/gcyr/data/recipe/chemistry/PolymerRecipes.java
@@ -99,7 +99,8 @@ public class PolymerRecipes {
                 .inputFluids(Water.getFluid(1000))
                 .outputFluids(HydrobromicAcid.getFluid(1000))
                 .duration(60).EUt(VA[HV]).save(provider);
-        MIXER_RECIPES.recipeBuilder(GCyR.id("co_mn_br_catalyst"))
+
+        LARGE_CHEMICAL_RECIPES.recipeBuilder(GCyR.id("co_mn_br_catalyst"))
                 .inputFluids(CobaltBromide.getFluid(1000))
                 .inputFluids(ManganeseBromide.getFluid(1000))
                 .inputFluids(ManganeseAcetate.getFluid(1000))


### PR DESCRIPTION
Mixer recipe type can only take 2 input fluids.  This "fixes" the recipe by making it an LCR recipe instead.

Could also come up with intermediate fluids and keep this in the mixer, but this is the smallest fix.

fixes #36 