### PR TITLE
fix kubejs maven config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,13 +109,22 @@ repositories {
     maven { // TOP
         url "https://maven.k-4u.nl"
     }
+
     maven {
-        // saps.dev Maven (KubeJS and Rhino)
-        url = "https://maven.saps.dev/minecraft"
+        url "https://maven.latvian.dev/releases"
         content {
             includeGroup "dev.latvian.mods"
+            includeGroup "dev.latvian.apps"
         }
     }
+
+    maven {
+        url 'https://jitpack.io'
+        content {
+            includeGroup "com.github.rtyley"
+        }
+    }
+
     mavenLocal()
     mavenCentral()
     maven { url = "https://maven.shedaniel.me/" } // Cloth Config, REI


### PR DESCRIPTION
Was having trouble building the latest version. Kubejs doesn't seem to be on the saps mirror anymore.  According to the kubejs git repos, this is the correct maven config.