### PR TITLE
Fix chips being duped on closing scanner GUI

### DIFF
--- a/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
+++ b/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
@@ -63,9 +63,6 @@ public class RocketScannerMachine extends PlatformMultiblockMachine implements I
     @Override
     public ModularUI createUI(Player entityPlayer) {
         ModularUI modularUI = super.createUI(entityPlayer);
-        modularUI.registerCloseListener(() -> {
-            Block.popResource(getLevel(), getPos(), posSaveSlot.getStackInSlot(0).copyAndClear());
-        });
         modularUI.widget(new SlotWidget(posSaveSlot, 0, 149, 105));
         modularUI.widget(new ButtonWidget(129, 105, 18, 18, this::onSaveButtonClick)
                 .setButtonTexture(GuiTextures.BUTTON)

--- a/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
+++ b/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
@@ -64,7 +64,7 @@ public class RocketScannerMachine extends PlatformMultiblockMachine implements I
     public ModularUI createUI(Player entityPlayer) {
         ModularUI modularUI = super.createUI(entityPlayer);
         modularUI.registerCloseListener(() -> {
-            Block.popResource(getLevel(), getPos(), posSaveSlot.getStackInSlot(0));
+            Block.popResource(getLevel(), getPos(), posSaveSlot.getStackInSlot(0).copyAndClear());
         });
         modularUI.widget(new SlotWidget(posSaveSlot, 0, 149, 105));
         modularUI.widget(new ButtonWidget(129, 105, 18, 18, this::onSaveButtonClick)

--- a/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
+++ b/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
@@ -63,6 +63,9 @@ public class RocketScannerMachine extends PlatformMultiblockMachine implements I
     @Override
     public ModularUI createUI(Player entityPlayer) {
         ModularUI modularUI = super.createUI(entityPlayer);
+        modularUI.registerCloseListener(() -> {
+            Block.popResource(getLevel(), getPos(), posSaveSlot.getStackInSlot(0).copyAndClear());
+        });
         modularUI.widget(new SlotWidget(posSaveSlot, 0, 149, 105));
         modularUI.widget(new ButtonWidget(129, 105, 18, 18, this::onSaveButtonClick)
                 .setButtonTexture(GuiTextures.BUTTON)


### PR DESCRIPTION
Slot wasn't being cleared after popping item, so the chips were effectively being duped.
Fixes this by using ItemStack#copyAndClear() which works