### PR TITLE
Enable downloading sources and javadocs for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,6 +263,13 @@ components.java {
     }
 }
 
+idea {
+    module {
+        downloadSources = true
+        downloadJavadoc = true
+    }
+}
+
 publishing {
     publications {
         mavenForge(MavenPublication) {


### PR DESCRIPTION
Apparently IntelliJ Idea doesn't do this anymore by default