### PR TITLE
Fix block inventory models

### DIFF
--- a/src/generated/resources/assets/gcyr/models/item/aerospace_aluminium_casing.json
+++ b/src/generated/resources/assets/gcyr/models/item/aerospace_aluminium_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/aerospace_aluminium_casing"
+}

--- a/src/generated/resources/assets/gcyr/models/item/beam_receiver.json
+++ b/src/generated/resources/assets/gcyr/models/item/beam_receiver.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/beam_receiver"
+}

--- a/src/generated/resources/assets/gcyr/models/item/dyson_solar_cell.json
+++ b/src/generated/resources/assets/gcyr/models/item/dyson_solar_cell.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/dyson_solar_cell"
+}

--- a/src/generated/resources/assets/gcyr/models/item/dyson_sphere_casing.json
+++ b/src/generated/resources/assets/gcyr/models/item/dyson_sphere_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/dyson_sphere_casing"
+}

--- a/src/generated/resources/assets/gcyr/models/item/dyson_sphere_maintenance_port.json
+++ b/src/generated/resources/assets/gcyr/models/item/dyson_sphere_maintenance_port.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/dyson_sphere_maintenance_port"
+}

--- a/src/generated/resources/assets/gcyr/models/item/moon_sand.json
+++ b/src/generated/resources/assets/gcyr/models/item/moon_sand.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/moon_sand"
+}

--- a/src/generated/resources/assets/gcyr/models/item/space_elevator_support.json
+++ b/src/generated/resources/assets/gcyr/models/item/space_elevator_support.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/space_elevator_support"
+}

--- a/src/generated/resources/assets/gcyr/models/item/stainless_evaporation_casing.json
+++ b/src/generated/resources/assets/gcyr/models/item/stainless_evaporation_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "gcyr:block/stainless_evaporation_casing"
+}

--- a/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
@@ -265,7 +265,6 @@ public class GCYRBlocks {
             .tag(BlockTags.MINEABLE_WITH_SHOVEL)
             .blockstate(NonNullBiConsumer.noop())
             .item()
-            //.model((ctx, prov) -> prov.blockItem(GCYRBlocks.MOON_SAND))
             .build()
             .register();
 

--- a/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
@@ -265,7 +265,7 @@ public class GCYRBlocks {
             .tag(BlockTags.MINEABLE_WITH_SHOVEL)
             .blockstate(NonNullBiConsumer.noop())
             .item()
-            .model(NonNullBiConsumer.noop())
+            //.model((ctx, prov) -> prov.blockItem(GCYRBlocks.MOON_SAND))
             .build()
             .register();
 
@@ -542,7 +542,6 @@ public class GCYRBlocks {
                 .blockstate(GCYRModels.cubeAllModel(name, texture))
                 .tag(GCYRTags.MINEABLE_WITH_WRENCH, BlockTags.MINEABLE_WITH_PICKAXE)
                 .item(BlockItem::new)
-                .model(NonNullBiConsumer.noop())
                 .build()
                 .register();
     }


### PR DESCRIPTION
Lunar sand and all machine casings had their model set to NonNullBiConsumer.noop(), causing datagen to not generate item models for them