### PR TITLE
Make sky_objects optional in PlanetSkyRenderer

### DIFF
--- a/src/main/java/argent_matter/gcyr/api/space/planet/PlanetSkyRenderer.java
+++ b/src/main/java/argent_matter/gcyr/api/space/planet/PlanetSkyRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.Level;
 import org.joml.Vector3f;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -30,7 +31,7 @@ public record PlanetSkyRenderer(ResourceKey<Level> dimension, Optional<ResourceL
             WeatherEffects.CODEC.fieldOf("weather_effects").forGetter(PlanetSkyRenderer::weatherEffects),
             Codec.INT.fieldOf("horizon_angle").forGetter(PlanetSkyRenderer::horizonAngle),
             Codec.BOOL.optionalFieldOf("full_sky", false).forGetter(PlanetSkyRenderer::doFullSky),
-            SkyObject.CODEC.listOf().fieldOf("sky_objects").forGetter(PlanetSkyRenderer::skyObjects)
+            SkyObject.CODEC.listOf().optionalFieldOf("sky_objects", Collections.emptyList()).forGetter(PlanetSkyRenderer::skyObjects)
     ).apply(instance, PlanetSkyRenderer::new));
 
 

--- a/src/main/resources/assets/gcyr/gcyr/planet_assets/sky_renderers/venus.json
+++ b/src/main/resources/assets/gcyr/gcyr/planet_assets/sky_renderers/venus.json
@@ -12,5 +12,18 @@
   },
   "cloud_effects": "none",
   "weather_effects": "none",
-  "horizon_angle": 0
+  "horizon_angle": 0,
+  "sky_objects": [
+    {
+      "texture": "gcyr:textures/sky/sun.png",
+      "blending": true,
+      "render_type": "dynamic",
+      "scale": 90.0,
+      "rotation": [
+        0.0,
+        -90.0,
+        0.0
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Makes sky_objects an optional field in planet sky renderers, in case devs don't want any celestial objects. By default, it is an empty list.

Also adds a sun to Venus' skybox