### PR TITLE
Set refmap for mixins

### DIFF
--- a/src/main/resources/gcyr.mixins.json
+++ b/src/main/resources/gcyr.mixins.json
@@ -2,6 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "argent_matter.gcyr.mixin",
+    "refmap": "gcyr.refmap.json",
     "compatibilityLevel": "JAVA_17",
     "plugin": "argent_matter.gcyr.mixin.GCYRMixinPlugin",
     "mixins": [


### PR DESCRIPTION
A refmap wasn't defined for GCYR in `gcyr.mixins.json`. Thank you @jmoiron for catching this