### PR TITLE
add a filter to the planet ID chip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
     id 'maven-publish'
 
     alias libs.plugins.modDevGradle
-    alias libs.plugins.spotless
+    //alias libs.plugins.spotless
     alias libs.plugins.lombok
-    alias libs.plugins.shadow
+    //alias libs.plugins.shadow
 }
 
 group = project.properties.maven_group
@@ -100,4 +100,5 @@ apply from: "$rootDir/gradle/scripts/repositories.gradle"
 apply from: "$projectDir/dependencies.gradle"
 apply from: "$rootDir/gradle/scripts/resources.gradle"
 apply from: "$rootDir/gradle/scripts/publishing.gradle"
-apply from: "$rootDir/gradle/scripts/spotless.gradle"
+// apply from: "$rootDir/gradle/scripts/spotless.gradle"
+

--- a/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
+++ b/src/main/java/argent_matter/gcyr/client/gui/screen/PlanetSelectionScreen.java
@@ -7,8 +7,11 @@ import argent_matter.gcyr.api.space.planet.Planet;
 import argent_matter.gcyr.api.space.planet.PlanetRing;
 import argent_matter.gcyr.api.space.planet.SolarSystem;
 import argent_matter.gcyr.client.gui.Category;
+import argent_matter.gcyr.common.data.GCYRItems;
 import argent_matter.gcyr.common.data.GCYRNetworking;
 import argent_matter.gcyr.common.gui.PlanetSelectionMenu;
+import argent_matter.gcyr.common.item.PlanetFilter;
+import argent_matter.gcyr.common.item.PlanetIdChipBehaviour;
 import argent_matter.gcyr.common.networking.c2s.PacketCreateSpaceStation;
 import argent_matter.gcyr.common.networking.c2s.PacketSendSelectedDimension;
 import argent_matter.gcyr.data.loader.PlanetData;
@@ -30,7 +33,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -205,6 +211,13 @@ public class PlanetSelectionScreen extends Screen implements MenuAccess<PlanetSe
         // sort planets based on their orbital period
         planets.sort(Comparator.comparing(p -> p.daysInYear()));
 
+        PlanetFilter filter = getActiveChipFilter();
+        if (!filter.isEmpty()) {
+            Set<ResourceLocation> allowed = new HashSet<>(filter.apply(
+                    planets.stream().map(p -> p.level().location()).toList()));
+            planets.removeIf(p -> !allowed.contains(p.level().location()));
+        }
+
         planets.forEach(planet -> {
             Category galaxyCategory = new Category(planet.galaxy(), Category.GALAXY_CATEGORY);
             Category solarSystemCategory = new Category(planet.solarSystem(), galaxyCategory);
@@ -246,6 +259,17 @@ public class PlanetSelectionScreen extends Screen implements MenuAccess<PlanetSe
     @Override
     public boolean isPauseScreen() {
         return true;
+    }
+
+    private PlanetFilter getActiveChipFilter() {
+        Player player = this.menu.getPlayer();
+        for (InteractionHand hand : InteractionHand.values()) {
+            ItemStack stack = player.getItemInHand(hand);
+            if (GCYRItems.ID_CHIP.isIn(stack)) {
+                return PlanetIdChipBehaviour.getFilter(stack);
+            }
+        }
+        return PlanetFilter.EMPTY;
     }
 
     public void onNavigationButtonClick(Category target) {

--- a/src/main/java/argent_matter/gcyr/common/item/PlanetFilter.java
+++ b/src/main/java/argent_matter/gcyr/common/item/PlanetFilter.java
@@ -1,0 +1,57 @@
+package argent_matter.gcyr.common.item;
+
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public record PlanetFilter(@Nullable Set<ResourceLocation> accept, @Nullable Set<ResourceLocation> deny) {
+    public static final PlanetFilter EMPTY = new PlanetFilter(null, null);
+
+    public List<ResourceLocation> apply(List<ResourceLocation> dimensionIds) {
+        List<ResourceLocation> result;
+        if (accept != null) {
+            result = new ArrayList<>(dimensionIds);
+            result.retainAll(accept);
+        } else {
+            result = new ArrayList<>(dimensionIds);
+        }
+        if (deny != null) {
+            result.removeAll(deny);
+        }
+        return result;
+    }
+
+    public boolean isEmpty() {
+        return accept == null && deny == null;
+    }
+
+    public PlanetFilter addAccept(ResourceLocation id) {
+        Set<ResourceLocation> newAccept = accept != null ? new HashSet<>(accept) : new HashSet<>();
+        newAccept.add(id);
+        return new PlanetFilter(newAccept, deny);
+    }
+
+    public PlanetFilter removeAccept(ResourceLocation id) {
+        if (accept == null) return this;
+        Set<ResourceLocation> newAccept = new HashSet<>(accept);
+        newAccept.remove(id);
+        return new PlanetFilter(newAccept.isEmpty() ? null : newAccept, deny);
+    }
+
+    public PlanetFilter addDeny(ResourceLocation id) {
+        Set<ResourceLocation> newDeny = deny != null ? new HashSet<>(deny) : new HashSet<>();
+        newDeny.add(id);
+        return new PlanetFilter(accept, newDeny);
+    }
+
+    public PlanetFilter removeDeny(ResourceLocation id) {
+        if (deny == null) return this;
+        Set<ResourceLocation> newDeny = new HashSet<>(deny);
+        newDeny.remove(id);
+        return new PlanetFilter(accept, newDeny.isEmpty() ? null : newDeny);
+    }
+}

--- a/src/main/java/argent_matter/gcyr/common/item/PlanetIdChipBehaviour.java
+++ b/src/main/java/argent_matter/gcyr/common/item/PlanetIdChipBehaviour.java
@@ -10,7 +10,10 @@ import com.gregtechceu.gtceu.api.item.component.IInteractionItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -25,12 +28,15 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class PlanetIdChipBehaviour implements IInteractionItem, IAddInformation {
     public static final String CURRENT_STATION_KEY = "gcyr:current_station";
     public static final String CURRENT_PLANET_KEY = "gcyr:current_planet";
     public static final String CURRENT_POS_KEY = "gcyr:current_position";
+    public static final String FILTER_KEY = "gcyr:filter";
 
     @Override
     public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand usedHand) {
@@ -71,6 +77,59 @@ public class PlanetIdChipBehaviour implements IInteractionItem, IAddInformation 
         ResourceLocation currentLevel = new ResourceLocation(stack.getTag().getString(CURRENT_PLANET_KEY));
         return GlobalPos.of(ResourceKey.create(Registries.DIMENSION, currentLevel),
                 NbtUtils.readBlockPos(stack.getTag().getCompound(CURRENT_POS_KEY)));
+    }
+
+    public static PlanetFilter getFilter(ItemStack stack) {
+        if (!stack.hasTag() || !stack.getTag().contains(FILTER_KEY, Tag.TAG_COMPOUND)) {
+            return PlanetFilter.EMPTY;
+        }
+        CompoundTag filterTag = stack.getTag().getCompound(FILTER_KEY);
+        Set<ResourceLocation> accept = readLocationSet(filterTag, "accept");
+        Set<ResourceLocation> deny = readLocationSet(filterTag, "deny");
+        if (accept == null && deny == null) {
+            return PlanetFilter.EMPTY;
+        }
+        return new PlanetFilter(accept, deny);
+    }
+
+    @Nullable
+    private static Set<ResourceLocation> readLocationSet(CompoundTag tag, String key) {
+        if (!tag.contains(key, Tag.TAG_LIST)) return null;
+        ListTag listTag = tag.getList(key, Tag.TAG_STRING);
+        Set<ResourceLocation> result = new HashSet<>();
+        for (Tag entry : listTag) {
+            ResourceLocation loc = ResourceLocation.tryParse(entry.getAsString());
+            if (loc != null) {
+                result.add(loc);
+            }
+        }
+        return result;
+    }
+
+    public static void setFilter(ItemStack stack, PlanetFilter filter) {
+        if (!GCYRItems.ID_CHIP.isIn(stack)) return;
+        if (filter.isEmpty()) {
+            if (stack.hasTag()) {
+                stack.getTag().remove(FILTER_KEY);
+            }
+            return;
+        }
+        CompoundTag filterTag = new CompoundTag();
+        if (filter.accept() != null) {
+            ListTag acceptTag = new ListTag();
+            for (ResourceLocation loc : filter.accept()) {
+                acceptTag.add(StringTag.valueOf(loc.toString()));
+            }
+            filterTag.put("accept", acceptTag);
+        }
+        if (filter.deny() != null) {
+            ListTag denyTag = new ListTag();
+            for (ResourceLocation loc : filter.deny()) {
+                denyTag.add(StringTag.valueOf(loc.toString()));
+            }
+            filterTag.put("deny", denyTag);
+        }
+        stack.getOrCreateTag().put(FILTER_KEY, filterTag);
     }
 
     @Override

--- a/src/main/resources/gcyr.mixins.json
+++ b/src/main/resources/gcyr.mixins.json
@@ -2,6 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "argent_matter.gcyr.mixin",
+    "refmap": "gcyr.refmap.json",
     "compatibilityLevel": "JAVA_17",
     "plugin": "argent_matter.gcyr.mixin.GCYRMixinPlugin",
     "mixins": [


### PR DESCRIPTION
It's common for pack developers to design a "planet hopping" experience where players have to accomplish something on a set of planets/moons before gaining access to the next set of worlds. AR had a comprehensive research system (which I think never worked) as well as a warp drive mechanic that let developers require an item in order to "unlock" warp travel to specific dimensions. GTNH uses like 8 tiers of galacticraft rocket to do this.

GCYR's 3 tier engine/tank system is comparatively inflexible.

This was the smallest addition I could think of that allows for this kind of design. This change adds a `filter` NBT to the PlanetIdChip. This filter contains an accept/deny list of dimension resource IDs, eg:

```js
/give @s gcyr:id_chip{"gcyr:filter":{accept:["minecraft:overworld","gcyr:luna"]}} 
```

This filters the planet selection screen so that the player only has access to terra & luna. If "deny" is present, any dimension in "deny" is explicitly excluded (even if it is in `accept`). If the filter is not present, the behavior is unchanged.

(the PR also includes Juicey's refmap change and the temporary removal of shadow & spotless gradle plugins so I could playtest this and not explode the diff)