### PR TITLE
fix rocket entity duping inventories when forming

### DIFF
--- a/src/main/java/argent_matter/gcyr/client/renderer/entity/RocketEntityRenderer.java
+++ b/src/main/java/argent_matter/gcyr/client/renderer/entity/RocketEntityRenderer.java
@@ -4,6 +4,7 @@ import argent_matter.gcyr.common.entity.RocketEntity;
 import argent_matter.gcyr.util.PosWithState;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
@@ -13,6 +14,9 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
@@ -39,15 +43,31 @@ public class RocketEntityRenderer extends EntityRenderer<RocketEntity> {
                        MultiBufferSource buffer, int packedLight) {
         poseStack.pushPose();
 
-        // render blocks
         for (PosWithState state : entity.getBlocks()) {
             poseStack.pushPose();
             BlockPos pos = state.pos();
             poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
-            blockRenderer.getModelRenderer().renderModel(poseStack.last(),
-                    buffer.getBuffer(Sheets.translucentCullBlockSheet()),
-                    state.state(), blockRenderer.getBlockModel(state.state()),
-                    1, 1, 1, packedLight, OverlayTexture.NO_OVERLAY);
+
+            if (state.state().getRenderShape() == RenderShape.ENTITYBLOCK_ANIMATED &&
+                    state.state().getBlock() instanceof EntityBlock entityBlock) {
+                BlockEntity fakeEntity = entityBlock.newBlockEntity(BlockPos.ZERO, state.state());
+                if (fakeEntity != null) {
+                    // Setting the level makes ChestRenderer (and similar) use getBlockState()
+                    // rather than a hardcoded south-facing fallback, giving correct orientation.
+                    fakeEntity.setLevel(entity.level());
+                    if (state.entityTag() != null) {
+                        fakeEntity.load(state.entityTag());
+                    }
+                    Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(fakeEntity,
+                            poseStack, buffer, packedLight, OverlayTexture.NO_OVERLAY);
+                }
+            } else {
+                blockRenderer.getModelRenderer().renderModel(poseStack.last(),
+                        buffer.getBuffer(Sheets.translucentCullBlockSheet()),
+                        state.state(), blockRenderer.getBlockModel(state.state()),
+                        1, 1, 1, packedLight, OverlayTexture.NO_OVERLAY);
+            }
+
             poseStack.popPose();
         }
 

--- a/src/main/java/argent_matter/gcyr/common/data/GCYREntityDataSerializers.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYREntityDataSerializers.java
@@ -70,7 +70,7 @@ public class GCYREntityDataSerializers {
 
         @Override
         public PosWithState copy(PosWithState value) {
-            return new PosWithState(value.pos(), value.state());
+            return new PosWithState(value.pos(), value.state(), value.entityTag());
         }
     };
 

--- a/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
+++ b/src/main/java/argent_matter/gcyr/common/machine/multiblock/RocketScannerMachine.java
@@ -28,6 +28,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -195,6 +196,10 @@ public class RocketScannerMachine extends PlatformMultiblockMachine implements I
                 @Nullable
                 CompoundTag entityTag = entry.getValue().getSecond();
                 rocket.addBlock(pos.subtract(startPos), state, entityTag);
+                BlockEntity be = getLevel().getBlockEntity(pos);
+                if (be instanceof Container container) {
+                    container.clearContent();
+                }
                 getLevel().setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
             }
             rocket.setPos(startPos.getX(), startPos.getY(), startPos.getZ());


### PR DESCRIPTION
Fixes #93 

Placing a chest or other container on a rocket and then building the rocket entity saved the container's contents to NBT, but when the RocketScanner's called `setBlockAndUpdate`, it would fire the block's `onRemove()` callback, which for a container calls `dropContents()` (eg. when you break a chest). When you unbuilt the rocket, the inventory would re-appear and have the old items, effectively duplicating its contents.

This changeset fixes two issues:

1. Chests were not rendering correctly before, because Chests are animated and `getBlockModel()` was returning an empty shape. There's a separate path now for animated entities, so now chests render properly on rocket entities. Double-chests will show as two single-chests though.
2. After the content of the chest is saved, its contents are cleared, so that there's nothing there when `dropContents()` fires. When you unbuild the rocket, the contents are restored as before.