### PR TITLE
fix magnetic iron foil recipes

### DIFF
--- a/src/main/java/argent_matter/gcyr/common/data/GCYRMaterials.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYRMaterials.java
@@ -24,6 +24,7 @@ public class GCYRMaterials {
 
     public static void modifyMaterials() {
         // Add flags to base GT materials
+        Iron.addFlags(GENERATE_FOIL);
         IronMagnetic.addFlags(GENERATE_FOIL);
         TitaniumTungstenCarbide.addFlags(GENERATE_ROD);
         Titanium.setProperty(PropertyKey.ORE, new OreProperty());

--- a/src/main/java/argent_matter/gcyr/data/recipe/RecipeOverrides.java
+++ b/src/main/java/argent_matter/gcyr/data/recipe/RecipeOverrides.java
@@ -1,5 +1,9 @@
 package argent_matter.gcyr.data.recipe;
 
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
+import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
+
 import net.minecraft.data.recipes.FinishedRecipe;
 
 import java.util.function.Consumer;
@@ -13,6 +17,30 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.*;
 public class RecipeOverrides {
 
     public static void init(Consumer<FinishedRecipe> provider) {
+
+        // processFoil generates the shaped recipe with iron_plate as input (the macerator output of
+        // IronMagnetic) and generates bender recipes that output iron_foil rather than magnetic_iron_foil.
+        // Override all three to use magnetic iron/magnetic iron plates and produce magnetic iron foil.
+        VanillaRecipeHelper.addShapedRecipe(provider, "foil_magnetic_iron",
+                ChemicalHelper.get(foil, IronMagnetic, 2),
+                "hP ", 'P', new MaterialEntry(plate, IronMagnetic));
+
+        BENDER_RECIPES.recipeBuilder("bend_magnetic_iron_plate_to_foil")
+                .inputItems(plate, IronMagnetic)
+                .outputItems(foil, IronMagnetic, 4)
+                .duration((int) IronMagnetic.getMass())
+                .EUt(24)
+                .circuitMeta(1)
+                .save(provider);
+
+        BENDER_RECIPES.recipeBuilder("bend_magnetic_iron_ingot_to_foil")
+                .inputItems(ingot, IronMagnetic)
+                .outputItems(foil, IronMagnetic, 4)
+                .duration((int) IronMagnetic.getMass())
+                .EUt(24)
+                .circuitMeta(10)
+                .save(provider);
+
         DISTILLATION_RECIPES.recipeBuilder("distill_coal_tar")
                 .inputFluids(CoalTar.getFluid(1000))
                 .outputItems(dustSmall, Coke)


### PR DESCRIPTION
The introduction of magnetic iron foil was responsible for an error in the console:

```
Tried to set output item stack that doesn't exist, id: gtceu:bend_magnetic_iron_plate_to_foil, TagPrefix: foil, Material: gtceu:iron, Count: 4
```

Additionally:
* it had a weird recipe where a hammer + iron plate -> magnetic iron foil
* you could not craft it in a bender

Adding foil attempts to auto-generate recipes, but _magnetic_ items are not really their own materials, they are flagged versions of existing ones. Adding magnetic iron foil w/o iron foil was confusing some of the automated recipe creation.

This changeset adds the "missing" iron foil, which unfortunately has no uses, and 3 more sensible ways to produce magnetic iron foil:

<img width="384" height="194" alt="2026-06-28_22 36 40" src="https://github.com/user-attachments/assets/b4bdca14-600b-4132-bd88-fce05ee31d09" />
<img width="523" height="305" alt="2026-06-28_22 36 44" src="https://github.com/user-attachments/assets/ad7c5d6d-e78d-4a4b-9312-54b9fa450d06" />
<img width="527" height="526" alt="2026-06-28_22 36 46" src="https://github.com/user-attachments/assets/ab8e4a74-426c-4e6d-9b1a-cefc91ea45e2" />
