### PR TITLE
Add missing tags for some blocks

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/cobblestone.json
+++ b/src/generated/resources/data/forge/tags/blocks/cobblestone.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "gcyr:mercury_cobblestone",
+    "gcyr:venus_cobblestone",
+    "gcyr:moon_cobblestone",
+    "gcyr:martian_cobblestone"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/stone.json
+++ b/src/generated/resources/data/forge/tags/blocks/stone.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "gcyr:mercury_rock",
+    "gcyr:venus_rock",
+    "gcyr:moon_stone",
+    "gcyr:martian_rock"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/mushrooms.json
+++ b/src/generated/resources/data/forge/tags/items/mushrooms.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "gcyr:prb_underground_mushroom",
+    "gcyr:prb_underground_bulb"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/doors.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/doors.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "gcyr:airlock_door"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/sand.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/sand.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "gcyr:venus_sand",
+    "gcyr:moon_sand"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/items/stone_tool_materials.json
+++ b/src/generated/resources/data/minecraft/tags/items/stone_tool_materials.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "gcyr:mercury_cobblestone",
+    "gcyr:venus_cobblestone",
+    "gcyr:moon_cobblestone",
+    "gcyr:martian_cobblestone"
+  ]
+}

--- a/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
@@ -19,6 +19,8 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.MapColor;
 
+import net.minecraftforge.common.Tags;
+
 import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
@@ -97,7 +99,7 @@ public class GCYRBlocks {
             .lang("Venus Sand")
             .initialProperties(() -> Blocks.SAND)
             .properties(properties -> properties.mapColor(MapColor.TERRACOTTA_ORANGE))
-            .tag(BlockTags.MINEABLE_WITH_SHOVEL)
+            .tag(BlockTags.MINEABLE_WITH_SHOVEL, BlockTags.SAND)
             .blockstate(GCYRModels::randomRotatedModel)
             .simpleItem()
             .register();
@@ -182,7 +184,7 @@ public class GCYRBlocks {
             .block("moon_sand", FallingBlock::new)
             .lang("Lunar Sand")
             .initialProperties(() -> Blocks.GRAVEL)
-            .tag(BlockTags.MINEABLE_WITH_SHOVEL)
+            .tag(BlockTags.MINEABLE_WITH_SHOVEL, BlockTags.SAND)
             .blockstate(NonNullBiConsumer.noop())
             .item()
             .build()
@@ -232,12 +234,11 @@ public class GCYRBlocks {
             .block("prb_underground_mushroom", (p) -> new MushroomBlock(p, null /* todo fix */))
             .lang("Proxima b Underground Mushroom")
             .initialProperties(() -> Blocks.BROWN_MUSHROOM)
-            .properties(p -> p.mapColor(MapColor.COLOR_LIGHT_GRAY).lightLevel((arg) -> {
-                return 11;
-            }))
+            .properties(p -> p.mapColor(MapColor.COLOR_LIGHT_GRAY).lightLevel((arg) -> 11))
             .addLayer(() -> RenderType::cutout)
             .blockstate(GCYRModels::crossModel)
             .item()
+            .tag(Tags.Items.MUSHROOMS)
             .model(GCYRModels::blockTextureGeneratedModel)
             .build()
             .register();
@@ -252,6 +253,7 @@ public class GCYRBlocks {
             .addLayer(() -> RenderType::cutout)
             .blockstate(GCYRModels::crossModel)
             .item()
+            .tag(Tags.Items.MUSHROOMS)
             .model(GCYRModels::blockTextureGeneratedModel)
             .build()
             .register();
@@ -312,7 +314,8 @@ public class GCYRBlocks {
             .initialProperties(() -> Blocks.IRON_BLOCK)
             .lang("Airlock Door")
             .properties(p -> p.strength(4.0F, 6.0F))
-            .tag(GCYRTags.MINEABLE_WITH_WRENCH, BlockTags.MINEABLE_WITH_PICKAXE, GCYRTags.BLOCKS_FLOOD_FILL)
+            .tag(GCYRTags.MINEABLE_WITH_WRENCH, BlockTags.MINEABLE_WITH_PICKAXE, GCYRTags.BLOCKS_FLOOD_FILL,
+                    BlockTags.DOORS)
             .blockstate(GCYRModels::airlockDoorModel)
             .item()
             .tag(ItemTags.DOORS)

--- a/src/main/java/argent_matter/gcyr/common/data/StoneVariant.java
+++ b/src/main/java/argent_matter/gcyr/common/data/StoneVariant.java
@@ -10,6 +10,8 @@ import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.MapColor;
 
+import net.minecraftforge.common.Tags;
+
 import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.util.entry.BlockEntry;
 
@@ -47,8 +49,8 @@ public class StoneVariant {
                 .initialProperties(() -> Blocks.COBBLESTONE)
                 .properties(p -> p.mapColor(mapColor))
                 .blockstate(GCYRModels::randomRotatedModel)
-                .tag(BlockTags.MINEABLE_WITH_PICKAXE)
-                .simpleItem();
+                .tag(BlockTags.MINEABLE_WITH_PICKAXE, Tags.Blocks.COBBLESTONE)
+                .item().tag(ItemTags.STONE_TOOL_MATERIALS).build();
     }
 
     // type is the ID segment for the stone block: "rock" or "stone"
@@ -59,7 +61,7 @@ public class StoneVariant {
                 .properties(p -> p.mapColor(mapColor))
                 .blockstate(GCYRModels::randomRotatedModel)
                 .loot((table, block) -> table.dropOther(block, cobblestone.asItem()))
-                .tag(BlockTags.MINEABLE_WITH_PICKAXE)
+                .tag(BlockTags.MINEABLE_WITH_PICKAXE, Tags.Blocks.STONE)
                 .simpleItem();
     }
 


### PR DESCRIPTION
Fixes #68 

Adds missing tags to our mushrooms, sand, cobblestone, and stone blocks