### PR TITLE
fix airlock door loot table so it only drops one door when broken

### DIFF
--- a/src/generated/resources/data/gcyr/loot_tables/blocks/airlock_door.json
+++ b/src/generated/resources/data/gcyr/loot_tables/blocks/airlock_door.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "gcyr:airlock_door",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "gcyr:airlock_door"
         }
       ],

--- a/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
+++ b/src/main/java/argent_matter/gcyr/common/data/GCYRBlocks.java
@@ -317,6 +317,7 @@ public class GCYRBlocks {
             .tag(GCYRTags.MINEABLE_WITH_WRENCH, BlockTags.MINEABLE_WITH_PICKAXE, GCYRTags.BLOCKS_FLOOD_FILL,
                     BlockTags.DOORS)
             .blockstate(GCYRModels::airlockDoorModel)
+            .loot((table, block) -> table.add(block, table.createDoorTable(block)))
             .item()
             .tag(ItemTags.DOORS)
             .defaultModel()


### PR DESCRIPTION
Airlock was missing a loot modifier that makes only the bottom half drop its item when broken.